### PR TITLE
Fix $.browser undefined variable comparison.

### DIFF
--- a/jquery.simulate.js
+++ b/jquery.simulate.js
@@ -29,7 +29,7 @@ $.simulate = function(el, type, options) {
 	} else {
 		this.simulateEvent(el, type, options);
 	}
-}
+};
 
 $.extend($.simulate.prototype, {
 	simulateEvent: function(el, type, options) {
@@ -94,7 +94,7 @@ $.extend($.simulate.prototype, {
 			evt = document.createEventObject();
 			$.extend(evt, e);
 		}
-		if ($.browser.msie || $.browser.opera) {
+		if (($.browser !== undefined) && ($.browser.msie || $.browser.opera)) {
 			evt.keyCode = (e.charCode > 0) ? e.charCode : e.keyCode;
 			evt.charCode = undefined;
 		}


### PR DESCRIPTION
This fix is related to an error found in one Drupal module:

http://drupal.org/node/1969724

Hope the fix is correct. Thanks for your time :)
