### PR TITLE
ie8 fireEvent method does not trigger default browser actions

### DIFF
--- a/jquery.simulate.js
+++ b/jquery.simulate.js
@@ -105,6 +105,13 @@ $.extend($.simulate.prototype, {
 		if (el.dispatchEvent) {
 			el.dispatchEvent(evt);
 		} else if (el.fireEvent) {
+			if  ((document.documentMode || 100) == 8 && type == 'click') {
+				// Hello ie8
+				el.click();
+			}
+			else {
+				el.fireEvent('on' + type, evt);
+			}
 			el.fireEvent('on' + type, evt);
 		}
 		return evt;


### PR DESCRIPTION
The default browser actions in ie8 are not triggered on a click event when simply using .fireEvent() method of an element. Only the hanlders are called.

This fix utilizes the [documentMode](http://msdn.microsoft.com/en-us/library/ie/cc196988%28v=vs.85%29.aspx) property to determine browser type and version. If we're on ie8 and we have a click event, then we simply call ie's [click](http://msdn.microsoft.com/en-us/library/ie/ms536363%28v=vs.85%29.aspx) method.
